### PR TITLE
Padroniza estrutura de diretórios

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 CC       ?= gcc
 CFLAGS   ?=
-CFLAGS   += -std=c99 -Wall -Wextra -Iinclude -MMD -MP
+INCLUDE_DIR := include
+CFLAGS   += -std=c99 -Wall -Wextra -I$(INCLUDE_DIR) -MMD -MP
 LDFLAGS  ?=
 LDLIBS   ?=
 
@@ -19,6 +20,7 @@ BIN_DIR  := $(BUILD_DIR)/bin
 OBJ_DIR  := $(BUILD_DIR)/obj
 SRC_DIR := src
 MODULES_DIR := modules
+CONFIG_DIR := config
 
 SRC_FILES := \
     $(wildcard $(SRC_DIR)/*.c) \

--- a/README.md
+++ b/README.md
@@ -29,5 +29,7 @@ make ENABLE_UDP=1 ENABLE_TLS=1
 - `include/` – header files
 - `modules/` – example and user-defined modules
 - `config/` – proxy configuration files
-- `logs/` – runtime logs
+- `tests/` – unit and integration tests
+- `tools/` – auxiliary scripts
+- `docs/` – technical documentation and guides
 - `build/` – compiled binaries and objects

--- a/config/proxy.conf
+++ b/config/proxy.conf
@@ -1,0 +1,4 @@
+listen_host = 127.0.0.1
+listen_port = 8080
+target_host = neverssl.com
+target_port = 80

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,1 @@
+Technical documentation and guides.

--- a/proxy.conf
+++ b/proxy.conf
@@ -1,4 +1,0 @@
-listen_host = 127.0.0.1
-listen_port = 8080
-target_host = neverssl.com
-target_port = 80

--- a/src/main.c
+++ b/src/main.c
@@ -7,7 +7,7 @@
 
 int main(void) {
     proxy_config_t config;
-    if (config_load("proxy.conf", &config) != 0)
+    if (config_load("config/proxy.conf", &config) != 0)
         return EXIT_FAILURE;
 
     if (proxy_register_module(register_logger_module()) != 0)

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,1 @@
+Unit and integration tests.

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,1 @@
+Auxiliary scripts.


### PR DESCRIPTION
## Resumo
- move proxy.conf para config/
- adiciona diretórios tests, tools e docs com arquivos de referência
- ajusta main para carregar config/proxy.conf e Makefile com variáveis de diretório

## Testes
- `make`
- `./build/release/bin/mitm-c`

------
https://chatgpt.com/codex/tasks/task_e_6897f37a8af083289df93b4c779661a5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration, documentation, and auxiliary script directories with descriptive README files.
  * Introduced a dedicated configuration file for proxy settings in the config directory.

* **Documentation**
  * Updated the main README to reflect the revised project structure and directory purposes.

* **Chores**
  * Improved build configuration by using variables for directory paths.
  * Updated the application to load configuration from the new location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->